### PR TITLE
use 'use strict'

### DIFF
--- a/src/SpectreClient.js
+++ b/src/SpectreClient.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const request = require('request-promise-native');
 
 module.exports = class SpectreClient {

--- a/test/runAll.js
+++ b/test/runAll.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
Fixes

```
/home/travis/build/zinserjan/wdio-visual-regression-service/node_modules/nodeclient-spectre/src/SpectreClient.js:3
module.exports = class SpectreClient {
                 ^^^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```