### PR TITLE
Add options param to createTestrun and spread them to Spectre

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,16 @@ Promise
     })
     .then((result) => {
         return spectreClientInstance.submitScreenshot("Testimage", "Testbrowser", 480, screenshot2Base64, result.id)
+    })
+    .then(() => {
+        const options = {
+            branch_name: 'test-branch',
+            commit: 'ab13dce'
+        };
+
+        return spectreClientInstance.createTestrun("Projekt", "Suite", options);
+    })
+    .then((result) => {
+        return spectreClientInstance.submitScreenshot("Testimage", "Testbrowser", 480, screenshot2Base64, result.id)
     });
 ```

--- a/src/SpectreClient.js
+++ b/src/SpectreClient.js
@@ -8,13 +8,14 @@ module.exports = class SpectreClient {
     }
 
 
-    createTestrun(projectName, suiteName) {
+    createTestrun(projectName, suiteName, options) {
         //format spectre_url to send post request to /runs
         let spectreUrlPost = this.spectreURL + '/runs';
 
         let formData = {
             project: projectName,
-            suite: suiteName
+            suite: suiteName,
+            ...options
         };
 
         return request({

--- a/test/runAll.js
+++ b/test/runAll.js
@@ -48,4 +48,16 @@ Promise
     .then((result) => {
         console.log(result);
         return result;
+    })
+    .then(() => {
+        const options = {
+            branch_name: 'test-branch',
+            commit: 'ab13dce'
+        };
+
+        return spectreClientInstance.createTestrun("Projekt", "Suite", options);
+    })
+    .then((result) => {
+        console.log(result);
+        return result;
     });


### PR DESCRIPTION
We are using [wdio-visual-regression-service](https://github.com/zinserjan/wdio-visual-regression-service) to create snapshots of our project and they use nodeclient-spectre to send them to Spectre.

We have a custom Spectre build that accepts more information when creating a Run, like commit and branch name.

I've added an options parameter when creating a new Run, than spread the options in the request body.